### PR TITLE
Carry relevant attributes over to the primary constructor

### DIFF
--- a/PrimaryConstructor.Sample/Program.cs
+++ b/PrimaryConstructor.Sample/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -40,6 +41,11 @@ namespace PrimaryConstructor.Sample
 
         // readonly prop will be injected
         public MyDependency MyDependency { get; }
+
+        // Attributes that can be used on parameters will be added to the constructor parameter
+        [Display(AutoGenerateField = true, Description = "Applicable to parameters")]
+        [DisplayFormat(DataFormatString = "Not applicable to parameters")]
+        public string WithAttributes { get; }
 
         // readonly prop with body will be ignored
         public NotRegisteredDependency IgnoredProperty1 => null;


### PR DESCRIPTION
This pull request is related to the feature suggested here: https://github.com/chaowlert/PrimaryConstructor/issues/10.

It is sometimes necessary to apply attributes to constructor parameters. For example something like this may be needed for dependency injection:

``` csharp
[PrimaryConstructor]
public partial class ShoppingCart
{
    [Inject(Optional = true)]
    private readonly Discount _discount;
}
```

Which results in the following code:

``` csharp
partial class ShoppingCart
{
    public ShoppingCart([Inject(Optional = true)] Discount discount)
    {
        this._discount = discount;
    }
}
```

Only attributes that can be applied to parameters are carried over.